### PR TITLE
Fix TypeScript type error in MainContentViewModel

### DIFF
--- a/src/ui/viewmodels/main-content-viewmodel.ts
+++ b/src/ui/viewmodels/main-content-viewmodel.ts
@@ -546,7 +546,7 @@ export class MainContentViewModel extends BaseViewModel {
       content: tab.content,
       isDirty: tab.isDirty,
       modelEntity: this._tabModelMap.get(tab.id)
-    }));
+    } as import('@core/entities/workspace').OpenedObject));
 
     // Update workspace opened objects
     this.workspace.setOpenedObjects(openedObjects);


### PR DESCRIPTION
- Add explicit type cast for OpenedObject in syncTabsToWorkspace method
- Resolves GitHub Actions build failure
- Required for proper workspace state synchronization

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>