### PR TITLE
🔧 Fix GitHub Pages Jekyll processing error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,10 +18,16 @@ export default defineConfig(({ command, mode }) => {
           if (isGitHubPages) {
             const outDir = 'docs';
             try {
+              // Create SPA fallback for client-side routing
               const indexHtml = fs.readFileSync(path.join(outDir, 'index.html'), 'utf-8');
               fs.writeFileSync(path.join(outDir, '404.html'), indexHtml);
+              
+              // Disable Jekyll processing for GitHub Pages
+              fs.writeFileSync(path.join(outDir, '.nojekyll'), '');
+              
+              console.log('Created GitHub Pages files: 404.html and .nojekyll');
             } catch (error) {
-              console.error('Failed to create 404.html for GitHub Pages:', error);
+              console.error('Failed to create GitHub Pages files:', error);
               // Continue build process despite the error
             }
           }


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions deployment error by disabling Jekyll processing for GitHub Pages, enabling proper SPA deployment.

### 🐛 Problem Fixed
- GitHub Actions was failing with: `No such file or directory @ dir_chdir0 - /github/workspace/docs`
- Jekyll was trying to process Vite-built SPA files as Jekyll source
- Missing `.nojekyll` file caused GitHub Pages to use Jekyll processing

### ✨ Solution Implemented
- **Auto-generate `.nojekyll`**: Added to Vite build process for GitHub Pages
- **Disable Jekyll processing**: Ensures SPA files are served as static content
- **Maintain SPA functionality**: Preserves client-side routing capabilities

### 🔧 Technical Changes
- Modified `vite.config.ts` to create `.nojekyll` during `build:github`
- Added proper console logging for build process visibility
- Integrated with existing GitHub Pages SPA fallback plugin

### 🚀 Expected Results
- ✅ GitHub Actions deployment succeeds
- ✅ SPA routing works correctly
- ✅ Hash-based demo routing functions: `/#demo`
- ✅ No more Jekyll processing errors

### 📋 Files Modified
- `vite.config.ts`: Added `.nojekyll` creation in writeBundle hook

## Test Plan
- [x] Local build generates `.nojekyll` correctly
- [x] TypeScript compilation passes
- [x] All tests passing
- [x] ESLint clean
- [ ] GitHub Actions deployment succeeds
- [ ] Live site functions correctly

This resolves the deployment blocker and enables the hash-based demo routing implemented in previous PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)